### PR TITLE
Update BigQuery Detokenization go.mod to Point at Common Module

### DIFF
--- a/bigquery/detokenize/go.mod
+++ b/bigquery/detokenize/go.mod
@@ -2,9 +2,6 @@ module github.com/skyflowapi/skyflow-integrations/bigquery/detokenize
 
 go 1.24.2
 
-// TODO: PP-942: remove this after migration to skyflow-integrations
-replace github.com/skyflowapi/skyflow-integrations/bigquery/common => ../common
-
 require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/onsi/ginkgo/v2 v2.23.4
@@ -12,7 +9,7 @@ require (
 	github.com/sethvargo/go-envconfig v1.3.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/skyflowapi/skyflow-go/commonutils v0.0.0-20250611120602-992855ae12b2
-	github.com/skyflowapi/skyflow-integrations/bigquery/common v0.0.0-00010101000000-000000000000
+	github.com/skyflowapi/skyflow-integrations/bigquery/common v0.0.1
 )
 
 require (

--- a/bigquery/detokenize/go.sum
+++ b/bigquery/detokenize/go.sum
@@ -87,6 +87,8 @@ github.com/skyflowapi/skyflow-go/serviceaccount v0.0.0-20250611120602-992855ae12
 github.com/skyflowapi/skyflow-go/serviceaccount v0.0.0-20250611120602-992855ae12b2/go.mod h1:AL67fN+eEm777DYDmX3j+aDYeA/wrp/m0+dGMW/IWBs=
 github.com/skyflowapi/skyflow-go/skyflow v0.0.0-20231031091049-3cf64b759f31 h1:lCxdz9eb4w64ZN12Z+wAunL5j7ymhhm3fFGEIv6m1rc=
 github.com/skyflowapi/skyflow-go/skyflow v0.0.0-20231031091049-3cf64b759f31/go.mod h1:k62C/yrwW+y1Yi265avPiEa1cHB9Yyh3VWqp/26g4xg=
+github.com/skyflowapi/skyflow-integrations/bigquery/common v0.0.1 h1:j4BkA1v8Nmd1EgkD7N/S5TECw9KCKbVdUlLOPbIVPKE=
+github.com/skyflowapi/skyflow-integrations/bigquery/common v0.0.1/go.mod h1:UhIoI1S4Llieb9W1tMAc29v9zeZbIwAw7+KN6CeQDd4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=


### PR DESCRIPTION
Updates `go.mod` in the BigQuery detokenization UDF module to point at the published `common` module version.