### PR TITLE
Download git in BigQuery Detokenization Dockerfile

### DIFF
--- a/bigquery/detokenize/Dockerfile
+++ b/bigquery/detokenize/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /app
 # Copy the Go modules files
 COPY go.mod go.sum ./
 
+# Download git
+RUN apk add --no-cache git
+
 # Download and cache the Go modules
 RUN go mod download
 


### PR DESCRIPTION
Installs git in the BigQuery detokenization UDF Dockerfile. Fixes the error where the Docker builder is unable to download the common module.