### PR TITLE
Add make target for adding copyright header to source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Skyflow, Inc.
+
+.PHONY: add-copyright
+
+add-copyright:
+# add #-style comments
+	find . -type f -name "*.tf" -o -name "Makefile" -o -name "Dockerfile" -o -name "*.sh" | xargs -I {} ./scripts/add-copyright.sh {} "# "
+# add //-style comments
+	find . -type f -name "*.go" | xargs -I {} ./scripts/add-copyright.sh {} "// "

--- a/bigquery/common/Makefile
+++ b/bigquery/common/Makefile
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Skyflow, Inc.
+
 .PHONY: format test coverage lint
 
 format:

--- a/bigquery/common/batching/batching.go
+++ b/bigquery/common/batching/batching.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package batching
 
 import (

--- a/bigquery/common/batching/batching_suite_test.go
+++ b/bigquery/common/batching/batching_suite_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package batching_test
 
 import (

--- a/bigquery/common/batching/batching_test.go
+++ b/bigquery/common/batching/batching_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package batching_test
 
 import (

--- a/bigquery/common/logging/logging.go
+++ b/bigquery/common/logging/logging.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package logging
 
 import (

--- a/bigquery/common/logging/logging_suite_test.go
+++ b/bigquery/common/logging/logging_suite_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package logging_test
 
 import (

--- a/bigquery/common/logging/logging_test.go
+++ b/bigquery/common/logging/logging_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package logging_test
 
 import (

--- a/bigquery/common/messaging/bigquery.go
+++ b/bigquery/common/messaging/bigquery.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package messaging
 
 import (

--- a/bigquery/common/messaging/bigquery_test.go
+++ b/bigquery/common/messaging/bigquery_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package messaging_test
 
 import (

--- a/bigquery/common/messaging/cloudrun.go
+++ b/bigquery/common/messaging/cloudrun.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package messaging
 
 import (

--- a/bigquery/common/messaging/cloudrun_test.go
+++ b/bigquery/common/messaging/cloudrun_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package messaging_test
 
 import (

--- a/bigquery/common/messaging/http.go
+++ b/bigquery/common/messaging/http.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package messaging
 
 import (

--- a/bigquery/common/messaging/http_test.go
+++ b/bigquery/common/messaging/http_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package messaging_test
 
 import (

--- a/bigquery/common/messaging/messaging_suite_test.go
+++ b/bigquery/common/messaging/messaging_suite_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package messaging_test
 
 import (

--- a/bigquery/common/messaging/skyflow/common.go
+++ b/bigquery/common/messaging/skyflow/common.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package skyflow
 
 import (

--- a/bigquery/common/messaging/skyflow/common_test.go
+++ b/bigquery/common/messaging/skyflow/common_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package skyflow_test
 
 import (

--- a/bigquery/common/messaging/skyflow/detokenize.go
+++ b/bigquery/common/messaging/skyflow/detokenize.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package skyflow
 
 import (

--- a/bigquery/common/messaging/skyflow/detokenize_test.go
+++ b/bigquery/common/messaging/skyflow/detokenize_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package skyflow_test
 
 import (

--- a/bigquery/common/messaging/skyflow/skyflow_suite_test.go
+++ b/bigquery/common/messaging/skyflow/skyflow_suite_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package skyflow_test
 
 import (

--- a/bigquery/common/middleware/middleware.go
+++ b/bigquery/common/middleware/middleware.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package middleware
 
 import (

--- a/bigquery/common/middleware/middleware_suite_test.go
+++ b/bigquery/common/middleware/middleware_suite_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package middleware_test
 
 import (

--- a/bigquery/common/middleware/middleware_test.go
+++ b/bigquery/common/middleware/middleware_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package middleware_test
 
 import (

--- a/bigquery/common/routing/router.go
+++ b/bigquery/common/routing/router.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package routing
 
 import (

--- a/bigquery/common/routing/router_test.go
+++ b/bigquery/common/routing/router_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package routing_test
 
 import (

--- a/bigquery/common/routing/routing_suite_test.go
+++ b/bigquery/common/routing/routing_suite_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package routing_test
 
 import (

--- a/bigquery/common/test/fixtures.go
+++ b/bigquery/common/test/fixtures.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package test
 
 import (

--- a/bigquery/detokenize/Dockerfile
+++ b/bigquery/detokenize/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Skyflow, Inc.
+
 # Use the official Golang image as a build stage
 FROM golang:1.24-alpine3.20 AS build
 

--- a/bigquery/detokenize/Makefile
+++ b/bigquery/detokenize/Makefile
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Skyflow, Inc.
+
 GCP_PROJECT_ID := ""
 IMAGE_NAME := detokenize
 IMAGE_TAG := $(shell date +%Y%m%d%H%M)

--- a/bigquery/detokenize/cmd/detokenize_suite_test.go
+++ b/bigquery/detokenize/cmd/detokenize_suite_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package main_test
 
 import (

--- a/bigquery/detokenize/cmd/main.go
+++ b/bigquery/detokenize/cmd/main.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package main
 
 import (

--- a/bigquery/detokenize/cmd/main_test.go
+++ b/bigquery/detokenize/cmd/main_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Skyflow, Inc.
+
 package main_test
 
 import (

--- a/bigquery/detokenize/terraform/main.tf
+++ b/bigquery/detokenize/terraform/main.tf
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Skyflow, Inc.
+
 # -- PROVIDERS --
 terraform {
   required_providers {

--- a/scripts/add-copyright.sh
+++ b/scripts/add-copyright.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright (c) 2025 Skyflow, Inc.
+
+# Accepts two arguments:
+# 1. The file to add the copyright header to
+# 2. A prefix to add to the copyright header
+# No spaces are added between the prefix and the copyright header.
+
+tmp_file=$(mktemp)
+file="$1"
+prefix="$2"
+copyright=$prefix"Copyright (c) 2025 Skyflow, Inc."
+skip_leading_lines=1
+
+if [ $(head -c 2 "$file") == "#!" ]; then
+    # there is a shebang, add the copyright header after the shebang
+    shebang=$(head -n 1 "$file")
+    # do not add a newline after the copyright header if a shebang was present
+    copyright="$shebang\n$copyright"
+    skip_leading_lines=2
+else
+    # no shebang, add a newline after the copyright header
+    copyright="$copyright\n"
+fi
+
+copyright_len=$(echo -e "$copyright" | wc -c)
+
+head -c $copyright_len "$file" | diff <(echo -e "$copyright") - > /dev/null || ( ( echo -e "$copyright"; tail -n +$skip_leading_lines "$file") > "$tmp_file"; cp "$tmp_file" "$file" )
+
+rm "$tmp_file"

--- a/spark/insert/scripts/dataproc_template_functions.sh
+++ b/spark/insert/scripts/dataproc_template_functions.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) 2025 Skyflow, Inc.
 
 # Check if an environment variable is set,
 # takes the name of the environment variable as an argument

--- a/spark/insert/scripts/start.sh
+++ b/spark/insert/scripts/start.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) 2025 Skyflow, Inc.
 set -e
 
 #Initialize functions and Constants


### PR DESCRIPTION
Adds copyright headers to all source files using a make target named `add-copyright` which scans the repo for missing copyright headers and adds the header where needed.