### PR TITLE
Add dependabot version updating config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/bigquery/detokenize"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/bigquery/detokenize"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/bigquery/detokenize/terraform"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/bigquery/common"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Configures dependabot to automatically create PRs updating dependency versions for all package ecosystems in the current project, including Go, Docker, and Terraform.